### PR TITLE
Fix progress bar calculation

### DIFF
--- a/Get-CompanyByVatId.ps1
+++ b/Get-CompanyByVatId.ps1
@@ -142,7 +142,7 @@ Write-Host "Processing $VatIdCount VAT IDs..."
 
 # Create progress bar
 $Progress = 0
-$ProgressStep = 100 / $VatIdCount
+$ProgressStep = 100 / [double]$VatIdCount
 
 # Create array for company objects
 $Companies = @()


### PR DESCRIPTION
## Summary
- prevent integer rounding when computing progress increments

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688b217a6a908321878d3dd5db94bb93